### PR TITLE
Allow international addresses

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,13 +3,7 @@ exports.isNotEmail = isNotEmail
 exports.isAsciiEmail = isAsciiEmail
 exports.isNotAsciiEmail = isNotAsciiEmail
 
-// Unicode ranges from RFC 3987
-//    ucschar        = %xA0-D7FF / %xF900-FDCF / %xFDF0-FFEF
-//       / %x10000-1FFFD / %x20000-2FFFD / %x30000-3FFFD
-//       / %x40000-4FFFD / %x50000-5FFFD / %x60000-6FFFD
-//       / %x70000-7FFFD / %x80000-8FFFD / %x90000-9FFFD
-//       / %xA0000-AFFFD / %xB0000-BFFFD / %xC0000-CFFFD
-//       / %xD0000-DFFFD / %xE1000-EFFFD
+// Unicode ranges from RFC 3987, section 2.2
 const unicodeRanges = [
   '\u00A0-\uD7FF',
   '\uF900-\uFDCF',

--- a/index.js
+++ b/index.js
@@ -1,8 +1,35 @@
 exports = module.exports = isEmail
 exports.isNotEmail = isNotEmail
 
-const localAddr = /^[a-z0-9.!#$%&'*+/=?^_`{|}~-]+$/i
-const domain = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)+$/i
+// Unicode ranges from RFC 3987
+//    ucschar        = %xA0-D7FF / %xF900-FDCF / %xFDF0-FFEF
+//       / %x10000-1FFFD / %x20000-2FFFD / %x30000-3FFFD
+//       / %x40000-4FFFD / %x50000-5FFFD / %x60000-6FFFD
+//       / %x70000-7FFFD / %x80000-8FFFD / %x90000-9FFFD
+//       / %xA0000-AFFFD / %xB0000-BFFFD / %xC0000-CFFFD
+//       / %xD0000-DFFFD / %xE1000-EFFFD
+const unicodeRanges = [
+  '\u00A0-\uD7FF',
+  '\uF900-\uFDCF',
+  '\uFDF0-\uFFEF',
+  '\u10000-\u1FFFD',
+  '\u20000-\u2FFFD',
+  '\u30000-\u3FFFD',
+  '\u40000-\u4FFFD',
+  '\u50000-\u5FFFD',
+  '\u60000-\u6FFFD',
+  '\u70000-\u7FFFD',
+  '\u80000-\u8FFFD',
+  '\u90000-\u9FFFD',
+  '\uA0000-\uAFFFD',
+  '\uB0000-\uBFFFD',
+  '\uC0000-\uCFFFD',
+  '\uD0000-\uDFFFD',
+  '\uE1000-\uEFFFD'
+].join('')
+const localAddr = new RegExp(`^[a-z0-9.!#$%&'*+/=?^_\`{|}~${unicodeRanges}-]+$`, 'i')
+const label = `[a-z0-9${unicodeRanges}](?:[a-z0-9${unicodeRanges}-]{0,61}[a-z0-9${unicodeRanges}])?`
+const domain = new RegExp(`^${label}(?:\\.${label})+$`, 'i')
 
 function isEmail (string) {
   const parts = string.split('@')

--- a/index.js
+++ b/index.js
@@ -28,8 +28,8 @@ const methods = [
   {
     name: 'isAsciiEmail',
     characters: '',
-    test: (parts) => {
-      const labels = parts[1].split('.')
+    test: (localAddr, domain) => {
+      const labels = domain.split('.')
       for (const label of labels) {
         if (label.indexOf('xn--') === 0) {
           return false
@@ -40,9 +40,9 @@ const methods = [
     }
   }
 ].reduce((methods, { characters, name, test }) => {
-  const localAddr = new RegExp(`^[a-z0-9.!#$%&'*+/=?^_\`{|}~${characters}-]+$`, 'i')
+  const localAddrRegex = new RegExp(`^[a-z0-9.!#$%&'*+/=?^_\`{|}~${characters}-]+$`, 'i')
   const label = `[a-z0-9${characters}](?:[a-z0-9${characters}-]{0,61}[a-z0-9${characters}])?`
-  const domain = new RegExp(`^${label}(?:\\.${label})+$`, 'i')
+  const domainRegex = new RegExp(`^${label}(?:\\.${label})+$`, 'i')
 
   methods[name] = (string) => {
     const parts = string.split('@')
@@ -51,19 +51,21 @@ const methods = [
       return false
     }
 
-    if (!localAddr.test(parts[0])) {
+    const [localAddr, domain] = parts
+
+    if (!localAddrRegex.test(localAddr)) {
       return false
     }
 
-    if (!domain.test(parts[1])) {
+    if (!domainRegex.test(domain)) {
       return false
     }
 
-    if (parts[ 0 ].substr(-1) === '.') {
+    if (localAddr.substr(-1) === '.') {
       return false
     }
 
-    return test(parts)
+    return test(localAddr, domain)
   }
 
   return methods

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 exports = module.exports = isEmail
 exports.isNotEmail = isNotEmail
+exports.isAsciiEmail = isAsciiEmail
+exports.isNotAsciiEmail = isNotAsciiEmail
 
 // Unicode ranges from RFC 3987
 //    ucschar        = %xA0-D7FF / %xF900-FDCF / %xFDF0-FFEF
@@ -28,8 +30,11 @@ const unicodeRanges = [
   '\uE1000-\uEFFFD'
 ].join('')
 const localAddr = new RegExp(`^[a-z0-9.!#$%&'*+/=?^_\`{|}~${unicodeRanges}-]+$`, 'i')
+const asciiLocalAddr = /^[a-z0-9.!#$%&'*+/=?^_`{|}~-]+$/i
 const label = `[a-z0-9${unicodeRanges}](?:[a-z0-9${unicodeRanges}-]{0,61}[a-z0-9${unicodeRanges}])?`
+const asciiLabel = '[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?'
 const domain = new RegExp(`^${label}(?:\\.${label})+$`, 'i')
+const asciiDomain = new RegExp(`^${asciiLabel}(?:\\.${asciiLabel})+$`, 'i')
 
 function isEmail (string) {
   const parts = string.split('@')
@@ -55,4 +60,37 @@ function isEmail (string) {
 
 function isNotEmail (string) {
   return !isEmail(string)
+}
+
+function isAsciiEmail (string) {
+  const parts = string.split('@')
+
+  if (parts.length !== 2) {
+    return false
+  }
+
+  if (!asciiLocalAddr.test(parts[0])) {
+    return false
+  }
+
+  if (!asciiDomain.test(parts[1])) {
+    return false
+  }
+
+  if (parts[ 0 ].substr(-1) === '.') {
+    return false
+  }
+
+  const labels = parts[1].split('.')
+  for (const label of labels) {
+    if (label.indexOf('xn--') === 0) {
+      return false
+    }
+  }
+
+  return true
+}
+
+function isNotAsciiEmail (string) {
+  return !isAsciiEmail(string)
 }

--- a/tests/unit/index.js
+++ b/tests/unit/index.js
@@ -33,7 +33,7 @@ exports.isEmail = {
   },
 
   'valid': function (test) {
-    test.expect(3)
+    test.expect(7)
 
     const longLabel = new Array(64).join('a')
 
@@ -43,6 +43,14 @@ exports.isEmail = {
       'Should accept 63 character domain labels.')
     test.strictEqual(isEmail(".!#$%&'*+/=?^_`{|}~-a9@example.com"), true,
       'Should accept certain special characters in local address.')
+    test.strictEqual(isEmail('👋@example.com'), true,
+      'Should accept unicode in local address')
+    test.strictEqual(isEmail('debt@👋.com'), true,
+      'Should accept unicode in domain')
+    test.strictEqual(isEmail('debt@xn--wp8h.com'), true,
+      'Should accept punycoded domains')
+    test.strictEqual(isEmail('debt@billing.👋.com'), true,
+      'Should accept unicode in every domain label')
     test.done()
   }
 }
@@ -79,7 +87,7 @@ exports.isNotEmail = {
   },
 
   'valid': function (test) {
-    test.expect(3)
+    test.expect(7)
 
     const longLabel = new Array(64).join('a')
 
@@ -89,6 +97,14 @@ exports.isNotEmail = {
       'Should accept 63 character domain labels.')
     test.strictEqual(isNotEmail(".!#$%&'*+/=?^_`{|}~-a9@example.com"), false,
       'Should accept certain special characters in local address.')
+    test.strictEqual(isNotEmail('👋@example.com'), false,
+      'Should accept unicode in local address')
+    test.strictEqual(isNotEmail('debt@👋.com'), false,
+      'Should accept unicode in domain')
+    test.strictEqual(isNotEmail('debt@xn--wp8h.com'), false,
+      'Should accept punycoded domains')
+    test.strictEqual(isNotEmail('debt@billing.👋.com'), false,
+      'Should accept unicode in every domain label')
     test.done()
   }
 }

--- a/tests/unit/index.js
+++ b/tests/unit/index.js
@@ -1,4 +1,6 @@
+const isAsciiEmail = require('../../index').isAsciiEmail
 const isEmail = require('../../index')
+const isNotAsciiEmail = require('../../index').isNotAsciiEmail
 const isNotEmail = require('../../index').isNotEmail
 
 exports.isEmail = {
@@ -55,6 +57,62 @@ exports.isEmail = {
   }
 }
 
+exports.isAsciiEmail = {
+  'empty': function (test) {
+    test.expect(1)
+    test.strictEqual(isEmail(''), false, 'Should not accept empty email.')
+    test.done()
+  },
+
+  'invalid': function (test) {
+    test.expect(13)
+
+    const longLabel = new Array(65).join('a')
+
+    test.strictEqual(isAsciiEmail('debt'), false,
+      'Cannot be local only.')
+    test.strictEqual(isAsciiEmail('@example.com'), false,
+      'Cannot be domain only.')
+    test.strictEqual(isAsciiEmail('debt@example'), false,
+      'Cannot have a domain with only one label.')
+    test.strictEqual(isAsciiEmail('debt@-example.com'), false,
+      'Cannot start domain with a hyphen.')
+    test.strictEqual(isAsciiEmail('debt@example-.com'), false,
+      'Cannot end domain with a hyphen.')
+    test.strictEqual(isAsciiEmail('debt@example!com'), false,
+      'Cannot contain special characters in domain.')
+    test.strictEqual(isAsciiEmail('debt@' + longLabel + '.com'), false,
+      'Cannot contain domain label >63 characters.')
+    test.strictEqual(isAsciiEmail('debt.@example.com'), false,
+      'Cannot end name with dot.')
+    test.strictEqual(isAsciiEmail('👋@example.com'), false,
+      'Should not accept unicode in local address')
+    test.strictEqual(isAsciiEmail('debt@👋.com'), false,
+      'Should not accept unicode in domain')
+    test.strictEqual(isAsciiEmail('debt@xn--wp8h.com'), false,
+      'Should not accept punycoded domains')
+    test.strictEqual(isAsciiEmail('debt@billing.xn--wp8h.com'), false,
+      'Should not accept any punycoded labels')
+    test.strictEqual(isAsciiEmail('debt@billing.👋.com'), false,
+      'Should not accept unicode in any domain label')
+    test.done()
+  },
+
+  'valid': function (test) {
+    test.expect(3)
+
+    const longLabel = new Array(64).join('a')
+
+    test.strictEqual(isAsciiEmail(longLabel + longLabel + '@example.com'), true,
+      'Should accept very long local address.')
+    test.strictEqual(isAsciiEmail('debt@' + longLabel + '.com'), true,
+      'Should accept 63 character domain labels.')
+    test.strictEqual(isAsciiEmail(".!#$%&'*+/=?^_`{|}~-a9@example.com"), true,
+      'Should accept certain special characters in local address.')
+    test.done()
+  }
+}
+
 exports.isNotEmail = {
   'empty': function (test) {
     test.expect(1)
@@ -105,6 +163,62 @@ exports.isNotEmail = {
       'Should accept punycoded domains')
     test.strictEqual(isNotEmail('debt@billing.👋.com'), false,
       'Should accept unicode in every domain label')
+    test.done()
+  }
+}
+
+exports.isNotAsciiEmail = {
+  'empty': function (test) {
+    test.expect(1)
+    test.strictEqual(isNotEmail(''), true, 'Should not accept empty email.')
+    test.done()
+  },
+
+  'invalid': function (test) {
+    test.expect(13)
+
+    const longLabel = new Array(65).join('a')
+
+    test.strictEqual(isNotAsciiEmail('debt'), true,
+      'Cannot be local only.')
+    test.strictEqual(isNotAsciiEmail('@example.com'), true,
+      'Cannot be domain only.')
+    test.strictEqual(isNotAsciiEmail('debt@example'), true,
+      'Cannot have a domain with only one label.')
+    test.strictEqual(isNotAsciiEmail('debt@-example.com'), true,
+      'Cannot start domain with a hyphen.')
+    test.strictEqual(isNotAsciiEmail('debt@example-.com'), true,
+      'Cannot end domain with a hyphen.')
+    test.strictEqual(isNotAsciiEmail('debt@example!com'), true,
+      'Cannot contain special characters in domain.')
+    test.strictEqual(isNotAsciiEmail('debt@' + longLabel + '.com'), true,
+      'Cannot contain domain label >63 characters.')
+    test.strictEqual(isNotAsciiEmail('debt.@example.com'), true,
+      'Cannot end name with dot.')
+    test.strictEqual(isNotAsciiEmail('👋@example.com'), true,
+      'Cannot contain unicode in local address')
+    test.strictEqual(isNotAsciiEmail('debt@👋.com'), true,
+      'Cannot contain unicode in domain')
+    test.strictEqual(isNotAsciiEmail('debt@xn--wp8h.com'), true,
+      'Cannot contain punycoded domains')
+    test.strictEqual(isNotAsciiEmail('debt@billing.xn--wp8h.com'), true,
+      'Cannot contain any punycoded labels')
+    test.strictEqual(isNotAsciiEmail('debt@billing.👋.com'), true,
+      'Cannot contain unicode in any domain label')
+    test.done()
+  },
+
+  'valid': function (test) {
+    test.expect(3)
+
+    const longLabel = new Array(64).join('a')
+
+    test.strictEqual(isNotAsciiEmail(longLabel + longLabel + '@example.com'), false,
+      'Should accept very long local address.')
+    test.strictEqual(isNotAsciiEmail('debt@' + longLabel + '.com'), false,
+      'Should accept 63 character domain labels.')
+    test.strictEqual(isNotAsciiEmail(".!#$%&'*+/=?^_`{|}~-a9@example.com"), false,
+      'Should accept certain special characters in local address.')
     test.done()
   }
 }


### PR DESCRIPTION
[International email addresses](https://en.wikipedia.org/wiki/International_email) are becoming more and more popular, validators shouldn't prevent that. In addition to the unit tests I've also verified this works with all the example emails from the wikipedia article.